### PR TITLE
Post testing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Version Scheme
 --------------
-Piiner uses the following versioning scheme, vX.X.X
+Pinner uses the following versioning scheme, vX.X.X
  - First Digit signifies a major (compatibility breaking) release
  - Second Digit signifies a major (non compatibility breaking) release
  - Third Digit signifies a minor or patch release

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -203,7 +203,7 @@ func (api *API) threadedPerformSweep() {
 	}
 	wg.Wait()
 	if cacheErr != nil {
-		err = errors.AddContext(cacheErr, "failed to revuild skyd cache")
+		err = errors.AddContext(cacheErr, "failed to rebuild skyd cache")
 		return
 	}
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -65,11 +65,11 @@ type (
 		// ServerName holds the name of the current server. This name will be
 		// used for identifying which servers are pinning a given skylink.
 		ServerName string
-		// SiaAPIPassword is the apipassword for the local skyd
+		// SiaAPIPassword is the apipassword for the local skyd.
 		SiaAPIPassword string
-		// SiaAPIHost is the hostname/IP of the local skyd
+		// SiaAPIHost is the hostname/IP of the local skyd.
 		SiaAPIHost string
-		// SiaAPIPort is the port of the local skyd
+		// SiaAPIPort is the port of the local skyd.
 		SiaAPIPort string
 	}
 )

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -221,9 +221,9 @@ func (db *DB) SkylinksForServer(ctx context.Context, server string) ([]string, e
 	if err != nil {
 		return nil, err
 	}
-	results := []struct {
+	var results []struct {
 		Skylink string
-	}{}
+	}
 	err = c.All(ctx, &results)
 	if err != nil {
 		return nil, errors.AddContext(err, "failed to decode results")

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -93,7 +93,7 @@ func (db *DB) FindSkylink(ctx context.Context, skylink skymodules.Skylink) (Skyl
 // that Pinner should make sure it's pinned by the minimum number of servers.
 func (db *DB) MarkPinned(ctx context.Context, skylink skymodules.Skylink) error {
 	db.staticLogger.Tracef("Entering MarkPinned. Skylink: '%s'", skylink)
-	defer db.staticLogger.Tracef("Exiting MarkPinned. Skylink: '%s'", skylink)
+	defer db.staticLogger.Tracef("Exiting  MarkPinned. Skylink: '%s'", skylink)
 	filter := bson.M{"skylink": skylink.String()}
 	update := bson.M{"$set": bson.M{"pinned": true}}
 	opts := options.Update().SetUpsert(true)
@@ -105,7 +105,7 @@ func (db *DB) MarkPinned(ctx context.Context, skylink skymodules.Skylink) error 
 // should stop pinning it.
 func (db *DB) MarkUnpinned(ctx context.Context, skylink skymodules.Skylink) error {
 	db.staticLogger.Tracef("Entering MarkUnpinned. Skylink: '%s'", skylink)
-	defer db.staticLogger.Tracef("Exiting MarkUnpinned. Skylink: '%s'", skylink)
+	defer db.staticLogger.Tracef("Exiting  MarkUnpinned. Skylink: '%s'", skylink)
 	filter := bson.M{"skylink": skylink.String()}
 	update := bson.M{"$set": bson.M{"pinned": false}}
 	opts := options.Update().SetUpsert(true)
@@ -125,7 +125,7 @@ func (db *DB) MarkUnpinned(ctx context.Context, skylink skymodules.Skylink) erro
 // a server sweep and documenting which skylinks are pinned by this server.
 func (db *DB) AddServerForSkylink(ctx context.Context, skylink skymodules.Skylink, server string, markPinned bool) error {
 	db.staticLogger.Tracef("Entering AddServerForSkylink. Skylink: '%s', server: '%s'", skylink, server)
-	defer db.staticLogger.Tracef("Exiting AddServerForSkylink. Skylink: '%s', server: '%s'", skylink, server)
+	defer db.staticLogger.Tracef("Exiting  AddServerForSkylink. Skylink: '%s', server: '%s'", skylink, server)
 	filter := bson.M{"skylink": skylink.String()}
 	var update bson.M
 	if markPinned {
@@ -146,7 +146,7 @@ func (db *DB) AddServerForSkylink(ctx context.Context, skylink skymodules.Skylin
 // not be inserted.
 func (db *DB) RemoveServerFromSkylink(ctx context.Context, skylink skymodules.Skylink, server string) error {
 	db.staticLogger.Tracef("Entering RemoveServerFromSkylink. Skylink: '%s', server: '%s'", skylink, server)
-	defer db.staticLogger.Tracef("Exiting RemoveServerFromSkylink. Skylink: '%s', server: '%s'", skylink, server)
+	defer db.staticLogger.Tracef("Exiting  RemoveServerFromSkylink. Skylink: '%s', server: '%s'", skylink, server)
 	filter := bson.M{
 		"skylink": skylink.String(),
 		"servers": server,
@@ -239,7 +239,7 @@ func (db *DB) SkylinksForServer(ctx context.Context, server string) ([]string, e
 // it to a new server.
 func (db *DB) UnlockSkylink(ctx context.Context, skylink skymodules.Skylink, server string) error {
 	db.staticLogger.Tracef("Entering UnlockSkylink. Skylink: '%s', server: '%s'", skylink, server)
-	defer db.staticLogger.Tracef("Exiting UnlockSkylink. Skylink: '%s', server: '%s'", skylink, server)
+	defer db.staticLogger.Tracef("Exiting  UnlockSkylink. Skylink: '%s', server: '%s'", skylink, server)
 	filter := bson.M{
 		"skylink":   skylink.String(),
 		"locked_by": server,

--- a/skyd/skyd.go
+++ b/skyd/skyd.go
@@ -79,7 +79,7 @@ func (c *client) DiffPinnedSkylinks(skylinks []string) (unknown []string, missin
 // Perfect health is 0.
 func (c *client) FileHealth(sp skymodules.SiaPath) (float64, error) {
 	c.staticLogger.Trace("Entering FileHealth.")
-	defer c.staticLogger.Trace("Exiting FileHealth.")
+	defer c.staticLogger.Trace("Exiting  FileHealth.")
 	rf, err := c.staticClient.RenterFileRootGet(sp)
 	if err != nil {
 		return 0, err
@@ -90,7 +90,7 @@ func (c *client) FileHealth(sp skymodules.SiaPath) (float64, error) {
 // Metadata returns the metadata of the skylink
 func (c *client) Metadata(skylink string) (skymodules.SkyfileMetadata, error) {
 	c.staticLogger.Trace("Entering Metadata.")
-	defer c.staticLogger.Trace("Exiting Metadata.")
+	defer c.staticLogger.Trace("Exiting  Metadata.")
 	_, meta, err := c.staticClient.SkynetMetadataGet(skylink)
 	if err != nil {
 		return skymodules.SkyfileMetadata{}, err
@@ -101,7 +101,7 @@ func (c *client) Metadata(skylink string) (skymodules.SkyfileMetadata, error) {
 // Pin instructs the local skyd to pin the given skylink.
 func (c *client) Pin(skylink string) (skymodules.SiaPath, error) {
 	c.staticLogger.Tracef("Entering Pin. Skylink: '%s'", skylink)
-	defer c.staticLogger.Tracef("Exiting Pin. Skylink: '%s'", skylink)
+	defer c.staticLogger.Tracef("Exiting  Pin. Skylink: '%s'", skylink)
 	_, err := database.SkylinkFromString(skylink)
 	if err != nil {
 		return skymodules.SiaPath{}, errors.Compose(err, database.ErrInvalidSkylink)
@@ -138,14 +138,14 @@ func (c *client) RenterDirRootGet(siaPath skymodules.SiaPath) (rd api.RenterDire
 // skylink is not V2.
 func (c *client) Resolve(skylink string) (string, error) {
 	c.staticLogger.Tracef("Entering Resolve. Skylink: '%s'", skylink)
-	defer c.staticLogger.Tracef("Exiting Resolve. Skylink: '%s'", skylink)
+	defer c.staticLogger.Tracef("Exiting  Resolve. Skylink: '%s'", skylink)
 	return c.staticClient.ResolveSkylinkV2(skylink)
 }
 
 // Unpin instructs the local skyd to unpin the given skylink.
 func (c *client) Unpin(skylink string) error {
 	c.staticLogger.Tracef("Entering Unpin. Skylink: '%s'", skylink)
-	defer c.staticLogger.Tracef("Exiting Unpin. Skylink: '%s'", skylink)
+	defer c.staticLogger.Tracef("Exiting  Unpin. Skylink: '%s'", skylink)
 	err := c.staticClient.SkynetSkylinkUnpinPost(skylink)
 	// Update the cached status of the skylink if there is no error or the error
 	// indicates that the skylink is blocked.
@@ -159,6 +159,6 @@ func (c *client) Unpin(skylink string) error {
 // skylink and returns true if it finds it.
 func (c *client) isPinned(skylink string) (bool, error) {
 	c.staticLogger.Tracef("Entering isPinned. Skylink: '%s'", skylink)
-	defer c.staticLogger.Tracef("Exiting isPinned. Skylink: '%s'", skylink)
+	defer c.staticLogger.Tracef("Exiting  isPinned. Skylink: '%s'", skylink)
 	return c.staticSkylinksCache.Contains(skylink), nil
 }

--- a/workers/scanner.go
+++ b/workers/scanner.go
@@ -314,7 +314,7 @@ func (s *Scanner) waitUntilHealthy(skylink skymodules.Skylink, sp skymodules.Sia
 		}
 		select {
 		case <-ticker.C:
-			s.staticLogger.Tracef("Waiting for '%s' to become fully healthy. Current health: %.2f", skylink, health)
+			s.staticLogger.Debugf("Waiting for '%s' to become fully healthy. Current health: %.2f", skylink, health)
 		case <-deadlineTimer.C:
 			s.staticLogger.Warnf("Skylink '%s' failed to reach full health within the time limit.", skylink)
 			break

--- a/workers/scanner.go
+++ b/workers/scanner.go
@@ -161,7 +161,7 @@ func (s *Scanner) threadedScanAndPin() {
 // pinUnderpinnedSkylinks loops over all underpinned skylinks and pins them.
 func (s *Scanner) pinUnderpinnedSkylinks() {
 	s.staticLogger.Trace("Entering pinUnderpinnedSkylinks.")
-	defer s.staticLogger.Trace("Exiting pinUnderpinnedSkylinks.")
+	defer s.staticLogger.Trace("Exiting  pinUnderpinnedSkylinks.")
 	for {
 		// Check for service shutdown before talking to the DB.
 		select {
@@ -187,7 +187,7 @@ func (s *Scanner) pinUnderpinnedSkylinks() {
 // such as bad credentials, dead skyd, etc.
 func (s *Scanner) findAndPinOneUnderpinnedSkylink() (skylink skymodules.Skylink, sf skymodules.SiaPath, continueScanning bool) {
 	s.staticLogger.Trace("Entering findAndPinOneUnderpinnedSkylink")
-	defer s.staticLogger.Trace("Exiting findAndPinOneUnderpinnedSkylink")
+	defer s.staticLogger.Trace("Exiting  findAndPinOneUnderpinnedSkylink")
 
 	sl, err := s.staticDB.FindAndLockUnderpinned(context.TODO(), s.staticServerName, s.minPinners)
 	if database.IsNoSkylinksNeedPinning(err) {

--- a/workers/scanner.go
+++ b/workers/scanner.go
@@ -37,9 +37,9 @@ import (
 
 // Handy constants used to improve readability.
 const (
+	assumedUploadSpeedInBytes = 1 << 30 / 4 / 8 // 25% of 1Gbps in bytes
 	baseSectorRedundancy      = 10
 	fanoutRedundancy          = 3
-	assumedUploadSpeedInBytes = 1 << 30 / 4 / 8 // 25% of 1Gbps in bytes
 )
 
 var (
@@ -182,18 +182,18 @@ func (s *Scanner) pinUnderpinnedSkylinks() {
 		if err == nil {
 			// Block until the pinned skylink becomes healthy or until a timeout.
 			s.waitUntilHealthy(skylink, sp)
-		} else {
-			// In case of error we still want to sleep for a moment in order to
-			// avoid a tight(ish) loop of errors when we either fail to pin or
-			// fail to mark as pinned. Note that this only happens when we want
-			// to continue scanning, otherwise we would have exited right after
-			// findAndPinOneUnderpinnedSkylink.
-			select {
-			case <-s.staticTG.StopChan():
-				s.staticLogger.Trace("Stop channel closed.")
-				return
-			case <-time.After(SleepBetweenPins):
-			}
+			continue
+		}
+		// In case of error we still want to sleep for a moment in order to
+		// avoid a tight(ish) loop of errors when we either fail to pin or
+		// fail to mark as pinned. Note that this only happens when we want
+		// to continue scanning, otherwise we would have exited right after
+		// findAndPinOneUnderpinnedSkylink.
+		select {
+		case <-s.staticTG.StopChan():
+			s.staticLogger.Trace("Stop channel closed.")
+			return
+		case <-time.After(SleepBetweenPins):
 		}
 	}
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

These are minor adjustments that I came up with while testing.

TL;DR:
 - when we get an non-breaking error (i.e. we continue processing other skylinks) while processing a skylink, we want to wait for a bit before moving on. this is both to avoid a tight loop around a faulty skylink as well giving more time for the cause of the error to go away, e.g. skyd to finish loading
 - slightly better logging

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
