### PR TITLE
Dry Run

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -38,6 +38,7 @@ jobs:
         run: make lint
       - name: Run unit tests
         run: make test
+      # TODO: Run long tests once we get mongo working in CI.
 
   # Make a release if this is a manually trigger job, i.e. workflow_dispatch
   release:

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,13 @@ all: release
 count = 1
 # pkgs changes which packages the makefile calls operate on. run changes which
 # tests are run during testing.
-pkgs = ./ ./api ./database ./skyd
+pkgs = ./ ./api ./database ./skyd ./test ./test/workers
 
 # integration-pkgs defines the packages which contain integration tests
 integration-pkgs = ./test ./test/api ./test/database
+
+# run determines which tests run when running any variation of 'make test'.
+run = .
 
 # fmt calls go fmt on all packages.
 fmt:

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -27,6 +27,12 @@ const (
 // Cluster-wide configuration variable names.
 // Stored in the database.
 const (
+	// ConfDryRun holds the name of the configuration setting which defines
+	// whether we execute pin/unpin calls against skyd or not. Note that all
+	// database operations will still be executed, i.e. skylinks records will
+	// be updated. After using this option you will need to prune the database
+	// before being able to use the service in "actual mode".
+	ConfDryRun = "dry_run"
 	// ConfMinPinners holds the name of the configuration setting which defines
 	// the minimum number of pinners we want to ensure for each skyfile.
 	ConfMinPinners = "min_pinners"
@@ -133,6 +139,24 @@ func LoadConfig() (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// DryRun returns the cluster-wide value of the dry_run switch. This switch
+// tells Pinner to omit the pin/unpin calls to skyd and assume they were
+// successful.
+func DryRun(ctx context.Context, db *database.DB) (bool, error) {
+	val, err := db.ConfigValue(ctx, ConfDryRun)
+	if errors.Contains(err, mongo.ErrNoDocuments) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	dr, err := strconv.ParseBool(val)
+	if err != nil {
+		return false, err
+	}
+	return dr, nil
 }
 
 // MinPinners returns the cluster-wide value of the minimum number of servers we

--- a/test/workers/scanner_test.go
+++ b/test/workers/scanner_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/skynetlabs/pinner/conf"
 	"github.com/skynetlabs/pinner/skyd"
 	"github.com/skynetlabs/pinner/test"
 	"github.com/skynetlabs/pinner/workers"
@@ -58,9 +59,100 @@ func TestScanner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Wait for one cycle - the skylink should be picked up and pinned on the
-	// local skyd.
-	time.Sleep(workers.SleepBetweenScans())
+
+	// Wait - the skylink should be picked up and pinned on the local skyd.
+	time.Sleep(3 * workers.SleepBetweenScans())
+
+	// Make sure the skylink is pinned on the local (mock) skyd.
+	if !skydcm.IsPinning(sl.String()) {
+		t.Fatal("We expected skyd to be pinning this.")
+	}
+}
+
+// TestScannerDryRun ensures that dry_run works as expected.
+func TestScannerDryRun(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	// Don't run this test in parallel since we set "dry_run". mongo is shared
+	// by the tests.
+
+	ctx := context.Background()
+	db, err := test.NewDatabase(ctx, t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Set dry_run: true.
+	err = db.SetConfigValue(ctx, conf.ConfDryRun, "true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err = db.SetConfigValue(ctx, conf.ConfDryRun, "false")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	cfg, err := test.LoadTestConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	skydcm := skyd.NewSkydClientMock()
+	scanner := workers.NewScanner(db, test.NewDiscardLogger(), cfg.MinPinners, cfg.ServerName, skydcm)
+	defer func() {
+		if e := scanner.Close(); e != nil {
+			t.Error(errors.AddContext(e, "failed to close threadgroup"))
+		}
+	}()
+	err = scanner.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Trigger a pin event.
+	//
+	// Add a skylink from the name of a different server.
+	sl := test.RandomSkylink()
+	otherServer := "other server"
+	_, err = db.CreateSkylink(ctx, sl, otherServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sleep for two cycles.
+	time.Sleep(2 * workers.SleepBetweenScans())
+	// Make sure the skylink isn't pinned on the local (mock) skyd.
+	if skydcm.IsPinning(sl.String()) {
+		t.Fatal("We didn't expect skyd to be pinning this.")
+	}
+	// Remove the other server, making the file underpinned.
+	err = db.RemoveServerFromSkylink(ctx, sl, otherServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait - the skylink should not be picked up and pinned on the local skyd.
+	time.Sleep(3 * workers.SleepBetweenScans())
+
+	// Verify skyd doesn't have the pin.
+	//
+	// Make sure the skylink is not pinned on the local (mock) skyd.
+	if skydcm.IsPinning(sl.String()) {
+		t.Fatal("We did not expect skyd to be pinning this.")
+	}
+
+	// Turn off dry run.
+	err = db.SetConfigValue(ctx, conf.ConfDryRun, "false")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify skyd gets the pin.
+	//
+	// Wait enough time for the pinner to pick up the new value for dry_run and
+	// rescan.
+	time.Sleep(10 * workers.SleepBetweenScans())
+
 	// Make sure the skylink is pinned on the local (mock) skyd.
 	if !skydcm.IsPinning(sl.String()) {
 		t.Fatal("We expected skyd to be pinning this.")

--- a/workers/scanner.go
+++ b/workers/scanner.go
@@ -147,9 +147,11 @@ func (s *Scanner) threadedScanAndPin() {
 				s.staticLogger.Warn(errors.AddContext(res.ExternErr, "failed to rebuild skyd client cache"))
 			}
 		}
+
 		s.refreshDryRun()
 		s.refreshMinPinners()
 		s.pinUnderpinnedSkylinks()
+
 		// Sleep between database scans.
 		select {
 		case <-time.After(SleepBetweenScans()):


### PR DESCRIPTION
# PULL REQUEST

## Overview

Implement a dry_run cluster-level configuration option which omits all calls to skyd's pin/unpin.

The feature is a bit raw and underspecced, so feedback is welcome. We need to get it done ASAP, though, so we can kick this off in prod. We can also make this a temporary feature and remove it once the Pinner is stable and trusted.

Even if, for some reason, we decide to not go with this feature, there are changes in this PR that still need to be merged, e.g. `findAndPinOneUnderpinnedSkylink` being renamed to `managedFindAndPinOneUnderpinnedSkylink` and the lock-and-copy strat in there.

Internal discussion: https://discord.com/channels/542938080349519882/978547799799005184/979044946185183294



This depends on https://github.com/SkynetLabs/pinner/pull/27 because I needed some of the changes made there.
I'll select that branch as base for the moment, in order to make the reviews easier.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
Closes SKY-676
