### PR TITLE
Implement a sweeping schedule.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -4,13 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sync"
-	"time"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/sirupsen/logrus"
 	"github.com/skynetlabs/pinner/database"
 	"github.com/skynetlabs/pinner/skyd"
+	"github.com/skynetlabs/pinner/sweeper"
 	"gitlab.com/NebulousLabs/errors"
 	"gitlab.com/SkynetLabs/skyd/build"
 )
@@ -23,17 +22,7 @@ type (
 		staticLogger     *logrus.Logger
 		staticRouter     *httprouter.Router
 		staticSkydClient skyd.Client
-
-		latestSweepStatus   SweepStatus
-		latestSweepStatusMu sync.Mutex
-	}
-
-	// SweepStatus represents the status of a sweep.
-	SweepStatus struct {
-		InProgress bool
-		Error      error
-		StartTime  time.Time
-		EndTime    time.Time
+		staticSweeper    *sweeper.Sweeper
 	}
 
 	// errorWrap is a helper type for converting an `error` struct to JSON.
@@ -43,7 +32,7 @@ type (
 )
 
 // New returns a new initialised API.
-func New(serverName string, db *database.DB, logger *logrus.Logger, skydClient skyd.Client) (*API, error) {
+func New(serverName string, db *database.DB, logger *logrus.Logger, skydClient skyd.Client, sweeper *sweeper.Sweeper) (*API, error) {
 	if db == nil {
 		return nil, errors.New("no DB provided")
 	}
@@ -59,6 +48,7 @@ func New(serverName string, db *database.DB, logger *logrus.Logger, skydClient s
 		staticLogger:     logger,
 		staticRouter:     router,
 		staticSkydClient: skydClient,
+		staticSweeper:    sweeper,
 	}
 	apiInstance.buildHTTPRoutes()
 	return apiInstance, nil

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -60,7 +60,7 @@ func (api *API) pinPOST(w http.ResponseWriter, req *http.Request, _ httprouter.P
 	// If the skylink already exists, add this server to its list of servers and
 	// mark the skylink as pinned.
 	if errors.Contains(err, database.ErrSkylinkExists) {
-		err = api.staticDB.AddServerForSkylink(req.Context(), sl, api.staticServerName, true)
+		err = api.staticDB.AddServerForSkylinks(req.Context(), []string{sl.String()}, api.staticServerName, true)
 	}
 	if err != nil {
 		api.WriteError(w, err, http.StatusInternalServerError)

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -1,17 +1,13 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
-	"sync"
-	"time"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/skynetlabs/pinner/conf"
 	"github.com/skynetlabs/pinner/database"
 	"gitlab.com/NebulousLabs/errors"
-	"gitlab.com/SkynetLabs/skyd/build"
 	"gitlab.com/SkynetLabs/skyd/skymodules"
 )
 
@@ -105,25 +101,13 @@ func (api *API) unpinPOST(w http.ResponseWriter, req *http.Request, _ httprouter
 // already running. The response is 202 Accepted and the response body contains
 // an endpoint link on which the caller can check the status of the sweep.
 func (api *API) sweepPOST(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
-	api.latestSweepStatusMu.Lock()
-	// If there is no sweep in progress - kick one off.
-	if !api.latestSweepStatus.InProgress {
-		go api.threadedPerformSweep()
-	}
-	api.latestSweepStatusMu.Unlock()
-	// TODO If we want to be able to uniquely identify sweeps we can issue ids
-	//  for them and keep their statuses in a map. This would be the appropriate
-	//  RESTful approach. I am not sure we need that because all we care about
-	//  is to be able to kick off one and wait for it to end and this
-	//  implementations is sufficient for that.
+	api.staticSweeper.Sweep()
 	api.WriteJSONCustomStatus(w, SweepPOSTResponse{"/sweep/status"}, http.StatusAccepted)
 }
 
 // sweepStatusGET responds with the status of the latest sweep.
 func (api *API) sweepStatusGET(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
-	api.latestSweepStatusMu.Lock()
-	defer api.latestSweepStatusMu.Unlock()
-	api.WriteJSON(w, api.latestSweepStatus)
+	api.WriteJSON(w, api.staticSweeper.Status())
 }
 
 // parseAndResolve parses the given string representation of a skylink and
@@ -145,97 +129,4 @@ func (api *API) parseAndResolve(skylink string) (skymodules.Skylink, error) {
 		}
 	}
 	return sl, nil
-}
-
-// threadedPerformSweep performs the actual sweep operation.
-// TODO This can be moved to a separate `sweeper` type which would also hold the
-//  status of the latest sweep as well as the relevant mutex. This can
-//  streamline the structure of API. I recommend this as a F/U.
-func (api *API) threadedPerformSweep() {
-	api.latestSweepStatusMu.Lock()
-	// Double-check for parallel sweeps.
-	if api.latestSweepStatus.InProgress {
-		api.latestSweepStatusMu.Unlock()
-		return
-	}
-	// Initialise the status to "a sweep is running".
-	api.latestSweepStatus = SweepStatus{
-		InProgress: true,
-		Error:      nil,
-		StartTime:  time.Now().UTC(),
-		EndTime:    time.Time{},
-	}
-	api.latestSweepStatusMu.Unlock()
-	// Define an error variable which will represent the success of the scan.
-	var err error
-	// Ensure that we'll finalize the sweep on returning from this method.
-	defer func() {
-		api.latestSweepStatusMu.Lock()
-		api.latestSweepStatus.InProgress = false
-		api.latestSweepStatus.EndTime = time.Now().UTC()
-		api.latestSweepStatus.Error = err
-		api.latestSweepStatusMu.Unlock()
-	}()
-
-	// Perform the actual sweep.
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	var cacheErr error
-	go func() {
-		defer wg.Done()
-		res := api.staticSkydClient.RebuildCache()
-		<-res.ErrAvail
-		cacheErr = res.ExternErr
-	}()
-
-	// We use an independent context because we are not strictly bound to a
-	// specific API call. Also, this operation can take significant amount of
-	// time and we don't want it to fail because of a timeout.
-	ctx := context.Background()
-	dbCtx, cancel := context.WithDeadline(ctx, time.Now().UTC().Add(database.MongoDefaultTimeout))
-	defer cancel()
-
-	// Get pinned skylinks from the DB
-	dbSkylinks, err := api.staticDB.SkylinksForServer(dbCtx, api.staticServerName)
-	if err != nil {
-		err = errors.AddContext(err, "failed to fetch skylinks for server")
-		return
-	}
-	wg.Wait()
-	if cacheErr != nil {
-		err = errors.AddContext(cacheErr, "failed to rebuild skyd cache")
-		return
-	}
-
-	unknown, missing := api.staticSkydClient.DiffPinnedSkylinks(dbSkylinks)
-
-	// Remove all unknown skylink from the database.
-	var s skymodules.Skylink
-	for _, sl := range unknown {
-		s, err = database.SkylinkFromString(sl)
-		if err != nil {
-			err = errors.AddContext(err, "invalid skylink found in DB")
-			build.Critical(err)
-			continue
-		}
-		err = api.staticDB.RemoveServerFromSkylink(ctx, s, api.staticServerName)
-		if err != nil {
-			err = errors.AddContext(err, "failed to unpin skylink")
-			return
-		}
-	}
-	// Add all missing skylinks to the database.
-	for _, sl := range missing {
-		s, err = database.SkylinkFromString(sl)
-		if err != nil {
-			err = errors.AddContext(err, "invalid skylink reported by skyd")
-			build.Critical(err)
-			continue
-		}
-		err = api.staticDB.AddServerForSkylink(ctx, s, api.staticServerName, false)
-		if err != nil {
-			err = errors.AddContext(err, "failed to unpin skylink")
-			return
-		}
-	}
 }

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	}
 	swpr := sweeper.New(db, skydClient, cfg.ServerName)
 	// Schedule a sweep every 24 hours.
-	swpr.Schedule(24 * time.Hour)
+	swpr.UpdateSchedule(24 * time.Hour)
 
 	// Initialise the server.
 	server, err := api.New(cfg.ServerName, db, logger, skydClient, swpr)

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	}
 	swpr := sweeper.New(db, skydClient, cfg.ServerName)
 	// Schedule a sweep every 24 hours.
-	swpr.Schedule().Update(24*time.Hour, swpr)
+	swpr.UpdateSchedule(24 * time.Hour)
 
 	// Initialise the server.
 	server, err := api.New(cfg.ServerName, db, logger, skydClient, swpr)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/skynetlabs/pinner/api"
@@ -12,6 +13,7 @@ import (
 	"github.com/skynetlabs/pinner/conf"
 	"github.com/skynetlabs/pinner/database"
 	"github.com/skynetlabs/pinner/skyd"
+	"github.com/skynetlabs/pinner/sweeper"
 	"github.com/skynetlabs/pinner/workers"
 	"gitlab.com/NebulousLabs/errors"
 )
@@ -46,9 +48,12 @@ func main() {
 	if err != nil {
 		log.Fatal(errors.AddContext(err, "failed to start Scanner"))
 	}
+	swpr := sweeper.New(db, skydClient, cfg.ServerName)
+	// Schedule a sweep every 24 hours.
+	swpr.Schedule(24 * time.Hour)
 
 	// Initialise the server.
-	server, err := api.New(cfg.ServerName, db, logger, skydClient)
+	server, err := api.New(cfg.ServerName, db, logger, skydClient, swpr)
 	if err != nil {
 		log.Fatal(errors.AddContext(err, "failed to build the api"))
 	}

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"log"
-	"time"
 
 	"github.com/skynetlabs/pinner/api"
 	"github.com/skynetlabs/pinner/build"
@@ -50,9 +49,9 @@ func main() {
 	if err != nil {
 		log.Fatal(errors.AddContext(err, "failed to start Scanner"))
 	}
-	swpr := sweeper.New(db, skydClient, cfg.ServerName)
-	// Schedule a sweep every 24 hours.
-	swpr.UpdateSchedule(24 * time.Hour)
+	swpr := sweeper.New(db, skydClient, cfg.ServerName, logger)
+	// Schedule a regular sweep..
+	swpr.UpdateSchedule(sweeper.SweepInterval)
 
 	// Initialise the server.
 	server, err := api.New(cfg.ServerName, db, logger, skydClient, swpr)

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	}
 	swpr := sweeper.New(db, skydClient, cfg.ServerName)
 	// Schedule a sweep every 24 hours.
-	swpr.UpdateSchedule(24 * time.Hour)
+	swpr.Schedule().Update(24*time.Hour, swpr)
 
 	// Initialise the server.
 	server, err := api.New(cfg.ServerName, db, logger, skydClient, swpr)

--- a/skyd/mock.go
+++ b/skyd/mock.go
@@ -107,7 +107,7 @@ func (c *ClientMock) Pin(skylink string) (skymodules.SiaPath, error) {
 func (c *ClientMock) RebuildCache() RebuildCacheResult {
 	closedCh := make(chan struct{})
 	close(closedCh)
-	// Do some work. There are tests which rely on this value to be above 50ms.
+	// Do some work. There are tests which rely on this value being above 50ms.
 	time.Sleep(100 * time.Millisecond)
 	return RebuildCacheResult{
 		errAvail:  closedCh,
@@ -261,4 +261,15 @@ func (c *ClientMock) MockFilesystem() []string {
 	c.SetMapping(dirDsp, rdrt)
 
 	return []string{slR0, slA1, slA2, slC0, slC1, slB0}
+}
+
+// Skylinks returns a list of all skylinks being held by this mock.
+func (c *ClientMock) Skylinks() []string {
+	c.mu.Lock()
+	sls := make([]string, len(c.skylinks), 0)
+	for sl := range c.skylinks {
+		sls = append(sls, sl)
+	}
+	c.mu.Unlock()
+	return sls
 }

--- a/sweeper/schedule.go
+++ b/sweeper/schedule.go
@@ -1,0 +1,56 @@
+package sweeper
+
+import (
+	"sync"
+	"time"
+)
+
+type (
+	// Schedule defines how often, if at all, we sweep this server automatically.
+	Schedule struct {
+		period   time.Duration
+		cancelCh chan struct{}
+		mu       sync.Mutex
+	}
+)
+
+// Update schedules a new series of sweeps to be run, using the given Sweeper.
+// If there are already scheduled sweeps, that staticSchedule is cancelled (running
+// sweeps are not interrupted) and a new staticSchedule is established.
+func (s *Schedule) Update(period time.Duration, sweeper *Sweeper) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if isOpen(s.cancelCh) {
+		close(s.cancelCh)
+	}
+
+	s.period = period
+	s.cancelCh = make(chan struct{})
+
+	go func() {
+		t := time.NewTicker(s.period)
+		for {
+			select {
+			case <-t.C:
+				sweeper.Sweep()
+			case <-s.cancelCh:
+				return
+			}
+		}
+	}()
+}
+
+// isOpen checks whether a channel is open (and not nil).
+// The question the function answers is "Can I close this?"
+func isOpen(ch chan struct{}) bool {
+	if ch == nil {
+		return false
+	}
+	select {
+	case _, open := <-ch:
+		return open
+	default:
+		return true
+	}
+}

--- a/sweeper/schedule.go
+++ b/sweeper/schedule.go
@@ -6,8 +6,8 @@ import (
 )
 
 type (
-	// Schedule defines how often, if at all, we sweep this server automatically.
-	Schedule struct {
+	// schedule defines how often, if at all, we sweep this server automatically.
+	schedule struct {
 		period   time.Duration
 		cancelCh chan struct{}
 		mu       sync.Mutex
@@ -15,9 +15,9 @@ type (
 )
 
 // Update schedules a new series of sweeps to be run, using the given Sweeper.
-// If there are already scheduled sweeps, that staticSchedule is cancelled (running
-// sweeps are not interrupted) and a new staticSchedule is established.
-func (s *Schedule) Update(period time.Duration, sweeper *Sweeper) {
+// If there are already scheduled sweeps, that schedule is cancelled (running
+// sweeps are not interrupted) and a new schedule is established.
+func (s *schedule) Update(period time.Duration, sweeper *Sweeper) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/sweeper/status.go
+++ b/sweeper/status.go
@@ -1,0 +1,64 @@
+package sweeper
+
+import (
+	"github.com/skynetlabs/pinner/logger"
+	"sync"
+	"time"
+)
+
+type (
+	// Status represents the status of a sweep.
+	Status struct {
+		InProgress bool
+		Error      error
+		StartTime  time.Time
+		EndTime    time.Time
+	}
+	// status is the internal status type that allows thread-safe updates.
+	status struct {
+		mu           sync.Mutex
+		staticLogger logger.ExtFieldLogger
+		status       Status
+	}
+)
+
+// Start marks the start of a new process, unless one is already in progress.
+// If there is a process in progress then Start returns without any action.
+func (st *status) Start() {
+	st.mu.Lock()
+	// Double-check for parallel sweeps.
+	if st.status.InProgress {
+		st.mu.Unlock()
+		st.staticLogger.Debug("Attempted to start a sweep while another one was already ongoing.")
+		return
+	}
+	// Initialise the status to "a sweep is running".
+	st.status.InProgress = true
+	st.status.Error = nil
+	st.status.StartTime = time.Now().UTC()
+	st.status.EndTime = time.Time{}
+	st.mu.Unlock()
+	st.staticLogger.Info("Started a sweep.")
+}
+
+// Status returns a copy of the current status.
+func (st *status) Status() Status {
+	st.mu.Lock()
+	s := st.status
+	st.mu.Unlock()
+	return s
+}
+
+// Finalize marks a run as completed with the given error.
+func (st *status) Finalize(err error) {
+	st.mu.Lock()
+	if !st.status.InProgress {
+		st.mu.Unlock()
+		return
+	}
+	st.status.InProgress = false
+	st.status.EndTime = time.Now().UTC()
+	st.status.Error = err
+	st.mu.Unlock()
+	st.staticLogger.Info("Finalized a sweep.")
+}

--- a/sweeper/status_test.go
+++ b/sweeper/status_test.go
@@ -1,0 +1,69 @@
+package sweeper
+
+import (
+	"github.com/sirupsen/logrus"
+	"gitlab.com/NebulousLabs/errors"
+	"io/ioutil"
+	"testing"
+	"time"
+)
+
+// TestStatus ensures the basic operation of the status type.
+func TestStatus(t *testing.T) {
+	logger := logrus.New()
+	logger.Out = ioutil.Discard
+
+	s := &status{staticLogger: logger}
+	sentinelErr := errors.New("this should not get set")
+
+	// isEmpty is a helper that returns true when the given status has its zero
+	// value.
+	isEmpty := func(st Status) bool {
+		return !(st.InProgress || st.Error != nil || (st.EndTime != time.Time{}) || (st.StartTime != time.Time{}))
+	}
+
+	// Check the status, expect not in progress.
+	st := s.Status()
+	if !isEmpty(st) {
+		t.Fatalf("Status not empty: %+v", st)
+	}
+	// Try to finalize before starting, expect nothing to happen.
+	s.Finalize(sentinelErr)
+	st = s.Status()
+	if !isEmpty(st) {
+		t.Fatalf("Status not empty: %+v", st)
+	}
+	// Start and verify.
+	s.Start()
+	st = s.Status()
+	if !st.InProgress || st.StartTime.After(time.Now().UTC()) {
+		t.Fatalf("Unexpected status: %+v", st)
+	}
+	// Store the start time and verify that attempting to start again will not
+	// change it.
+	startTime := st.StartTime
+	s.Start()
+	st = s.Status()
+	if st.StartTime != startTime {
+		t.Fatalf("Expected start time '%s', got '%s'", startTime, st.StartTime)
+	}
+	// Finalize and verify.
+	s.Finalize(sentinelErr)
+	st = s.Status()
+	if st.InProgress || !errors.Contains(st.Error, sentinelErr) || (st.EndTime == time.Time{}) {
+		t.Fatalf("Unexpected status: %+v", st)
+	}
+	// Save end time and verify that finalising again has no effect.
+	endTime := st.EndTime
+	s.Finalize(nil)
+	st = s.Status()
+	if st.EndTime != endTime || !errors.Contains(st.Error, sentinelErr) {
+		t.Fatalf("Unexpected status: %+v", st)
+	}
+	// Start the same status again.
+	s.Start()
+	st = s.Status()
+	if !st.InProgress || st.Error != nil {
+		t.Fatalf("Unexpected status: %+v", st)
+	}
+}

--- a/sweeper/sweeper.go
+++ b/sweeper/sweeper.go
@@ -15,7 +15,7 @@ import (
 type (
 	// Schedule defines how often, if at all, we sweep this server automatically.
 	Schedule struct {
-		Period   time.Duration
+		period   time.Duration
 		cancelCh chan struct{}
 	}
 	// Status represents the status of a sweep.
@@ -49,19 +49,19 @@ func New(db *database.DB, skydc skyd.Client, serverName string) *Sweeper {
 	}
 }
 
-// Schedule a scan to run on each period.
-func (s *Sweeper) Schedule(period time.Duration) {
+// UpdateSchedule schedules a scan to run on each period.
+func (s *Sweeper) UpdateSchedule(period time.Duration) {
 	s.scheduleMu.Lock()
 	defer s.scheduleMu.Unlock()
 	if s.schedule != nil {
 		close(s.schedule.cancelCh)
 	}
 	s.schedule = &Schedule{
-		Period:   period,
+		period:   period,
 		cancelCh: make(chan struct{}),
 	}
 	go func() {
-		t := time.NewTicker(s.schedule.Period)
+		t := time.NewTicker(s.schedule.period)
 		for {
 			select {
 			case <-t.C:
@@ -71,14 +71,6 @@ func (s *Sweeper) Schedule(period time.Duration) {
 			}
 		}
 	}()
-}
-
-// Scheduled returns a copy of the current Sweeper schedule.
-func (s *Sweeper) Scheduled() Schedule {
-	if s.schedule == nil {
-		return Schedule{}
-	}
-	return *s.schedule
 }
 
 // Status returns a copy of the status of the current sweep.

--- a/sweeper/sweeper.go
+++ b/sweeper/sweeper.go
@@ -22,7 +22,7 @@ type (
 	// and marks them as pinned by the local server.
 	Sweeper struct {
 		staticDB         *database.DB
-		staticSchedule   *Schedule
+		staticSchedule   *schedule
 		staticServerName string
 		staticSkydClient skyd.Client
 
@@ -37,13 +37,8 @@ func New(db *database.DB, skydc skyd.Client, serverName string) *Sweeper {
 		staticDB:         db,
 		staticSkydClient: skydc,
 		staticServerName: serverName,
-		staticSchedule:   &Schedule{},
+		staticSchedule:   &schedule{},
 	}
-}
-
-// Schedule returns the sweeper's schedule.
-func (s *Sweeper) Schedule() *Schedule {
-	return s.staticSchedule
 }
 
 // Status returns a copy of the status of the current sweep.
@@ -63,6 +58,13 @@ func (s *Sweeper) Status() Status {
 //  implementations is sufficient for that.
 func (s *Sweeper) Sweep() {
 	go s.threadedPerformSweep()
+}
+
+// UpdateSchedule schedules a new series of sweeps to be run.
+// If there are already scheduled sweeps, that schedule is cancelled (running
+// // sweeps are not interrupted) and a new schedule is established.
+func (s *Sweeper) UpdateSchedule(period time.Duration) {
+	s.staticSchedule.Update(period, s)
 }
 
 // threadedPerformSweep performs the actual sweep operation.

--- a/sweeper/sweeper.go
+++ b/sweeper/sweeper.go
@@ -83,7 +83,10 @@ func (s *Sweeper) Scheduled() Schedule {
 
 // Status returns a copy of the status of the current sweep.
 func (s *Sweeper) Status() Status {
-	return s.status
+	s.statusMu.Lock()
+	st := s.status
+	s.statusMu.Unlock()
+	return st
 }
 
 // Sweep starts a new skyd sweep, unless one is already underway.

--- a/sweeper/sweeper.go
+++ b/sweeper/sweeper.go
@@ -1,0 +1,188 @@
+package sweeper
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/skynetlabs/pinner/database"
+	"github.com/skynetlabs/pinner/skyd"
+	"gitlab.com/NebulousLabs/errors"
+	"gitlab.com/SkynetLabs/skyd/build"
+	"gitlab.com/SkynetLabs/skyd/skymodules"
+)
+
+type (
+	// Schedule defines how often, if at all, we sweep this server automatically.
+	Schedule struct {
+		Period   time.Duration
+		cancelCh chan struct{}
+	}
+	// Status represents the status of a sweep.
+	Status struct {
+		InProgress bool
+		Error      error
+		StartTime  time.Time
+		EndTime    time.Time
+	}
+	// Sweeper takes care of sweeping the files pinned by the local skyd server
+	// and marks them as pinned by the local server.
+	Sweeper struct {
+		staticDB         *database.DB
+		staticSkydClient skyd.Client
+		staticServerName string
+
+		schedule   *Schedule
+		scheduleMu sync.Mutex
+
+		status   Status
+		statusMu sync.Mutex
+	}
+)
+
+// New returns a new Sweeper.
+func New(db *database.DB, skydc skyd.Client, serverName string) *Sweeper {
+	return &Sweeper{
+		staticDB:         db,
+		staticSkydClient: skydc,
+		staticServerName: serverName,
+	}
+}
+
+// Schedule a scan to run on each period.
+func (s *Sweeper) Schedule(period time.Duration) {
+	s.scheduleMu.Lock()
+	defer s.scheduleMu.Unlock()
+	if s.schedule != nil {
+		close(s.schedule.cancelCh)
+	}
+	s.schedule = &Schedule{
+		Period:   period,
+		cancelCh: make(chan struct{}),
+	}
+	go func() {
+		t := time.NewTicker(s.schedule.Period)
+		for {
+			select {
+			case <-t.C:
+				s.Sweep()
+			case <-s.schedule.cancelCh:
+				return
+			}
+		}
+	}()
+}
+
+// Scheduled returns a copy of the current Sweeper schedule.
+func (s *Sweeper) Scheduled() Schedule {
+	if s.schedule == nil {
+		return Schedule{}
+	}
+	return *s.schedule
+}
+
+// Status returns a copy of the status of the current sweep.
+func (s *Sweeper) Status() Status {
+	return s.status
+}
+
+// Sweep starts a new skyd sweep, unless one is already underway.
+//
+// TODO If we want to be able to uniquely identify sweeps we can issue ids
+//  for them and keep their statuses in a map. This would be the appropriate
+//  RESTful approach. I am not sure we need that because all we care about
+//  is to be able to kick off one and wait for it to end and this
+//  implementations is sufficient for that.
+func (s *Sweeper) Sweep() {
+	go s.threadedPerformSweep()
+}
+
+// threadedPerformSweep performs the actual sweep operation.
+func (s *Sweeper) threadedPerformSweep() {
+	s.statusMu.Lock()
+	// Double-check for parallel sweeps.
+	if s.status.InProgress {
+		s.statusMu.Unlock()
+		return
+	}
+	// Initialise the status to "a sweep is running".
+	s.status = Status{
+		InProgress: true,
+		Error:      nil,
+		StartTime:  time.Now().UTC(),
+		EndTime:    time.Time{},
+	}
+	s.statusMu.Unlock()
+	// Define an error variable which will represent the success of the scan.
+	var err error
+	// Ensure that we'll finalize the sweep on returning from this method.
+	defer func() {
+		s.statusMu.Lock()
+		s.status.InProgress = false
+		s.status.EndTime = time.Now().UTC()
+		s.status.Error = err
+		s.statusMu.Unlock()
+	}()
+
+	// Perform the actual sweep.
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	var cacheErr error
+	go func() {
+		defer wg.Done()
+		res := s.staticSkydClient.RebuildCache()
+		<-res.ErrAvail
+		cacheErr = res.ExternErr
+	}()
+
+	// We use an independent context because we are not strictly bound to a
+	// specific API call. Also, this operation can take significant amount of
+	// time and we don't want it to fail because of a timeout.
+	ctx := context.Background()
+	dbCtx, cancel := context.WithDeadline(ctx, time.Now().UTC().Add(database.MongoDefaultTimeout))
+	defer cancel()
+
+	// Get pinned skylinks from the DB
+	dbSkylinks, err := s.staticDB.SkylinksForServer(dbCtx, s.staticServerName)
+	if err != nil {
+		err = errors.AddContext(err, "failed to fetch skylinks for server")
+		return
+	}
+	wg.Wait()
+	if cacheErr != nil {
+		err = errors.AddContext(cacheErr, "failed to rebuild skyd cache")
+		return
+	}
+
+	unknown, missing := s.staticSkydClient.DiffPinnedSkylinks(dbSkylinks)
+
+	// Remove all unknown skylink from the database.
+	var skylink skymodules.Skylink
+	for _, sl := range unknown {
+		skylink, err = database.SkylinkFromString(sl)
+		if err != nil {
+			err = errors.AddContext(err, "invalid skylink found in DB")
+			build.Critical(err)
+			continue
+		}
+		err = s.staticDB.RemoveServerFromSkylink(ctx, skylink, s.staticServerName)
+		if err != nil {
+			err = errors.AddContext(err, "failed to unpin skylink")
+			return
+		}
+	}
+	// Add all missing skylinks to the database.
+	for _, sl := range missing {
+		skylink, err = database.SkylinkFromString(sl)
+		if err != nil {
+			err = errors.AddContext(err, "invalid skylink reported by skyd")
+			build.Critical(err)
+			continue
+		}
+		err = s.staticDB.AddServerForSkylink(ctx, skylink, s.staticServerName, false)
+		if err != nil {
+			err = errors.AddContext(err, "failed to unpin skylink")
+			return
+		}
+	}
+}

--- a/test/sweeper/sweeper_test.go
+++ b/test/sweeper/sweeper_test.go
@@ -1,0 +1,63 @@
+package sweeper
+
+import (
+	"context"
+	"github.com/skynetlabs/pinner/skyd"
+	"github.com/skynetlabs/pinner/sweeper"
+	"github.com/skynetlabs/pinner/test"
+	"testing"
+	"time"
+)
+
+// TestSweeper ensures that Sweeper properly scans skyd and updates the DB.
+func TestSweeper(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	db, err := test.NewDatabase(ctx, t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	skydc := skyd.NewSkydClientMock()
+	serverName := t.Name()
+	logger := test.NewDiscardLogger()
+
+	// Ensure there are no skylinks pinned by this server, according to the DB.
+	sls, err := db.SkylinksForServer(ctx, serverName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sls) > 0 {
+		t.Fatalf("Expected no skylinks marked as pinned by this server, got %d", len(sls))
+	}
+
+	testSweepPeriod := 100 * time.Millisecond
+	swpr := sweeper.New(db, skydc, serverName, logger)
+	swpr.UpdateSchedule(testSweepPeriod)
+	defer swpr.Close()
+
+	// Wait for the sweep to come and go through.
+	// Rebuilding the cache will take 100ms.
+	time.Sleep(300 * time.Millisecond)
+
+	// Ensure the sweep passed and there are skylinks in the DB marked as pinned
+	// by this server.
+	sls, err = db.SkylinksForServer(ctx, serverName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Grab the skylinks available in the mock. We expect to see these in the DB.
+	mockSkylinks := skydc.Skylinks()
+	if len(sls) != len(mockSkylinks) {
+		t.Fatalf("Expected %d skylinks, got %d", len(mockSkylinks), len(sls))
+	}
+	// Ensure all skylinks are there.
+	for _, s := range mockSkylinks {
+		if !test.Contains(sls, s) {
+			t.Fatalf("Missing skylink '%s'", s)
+		}
+	}
+}

--- a/test/tester.go
+++ b/test/tester.go
@@ -70,7 +70,7 @@ func NewTester(dbName string) (*Tester, error) {
 
 	ctxWithCancel, cancel := context.WithCancel(ctx)
 	skydClientMock := skyd.NewSkydClientMock()
-	swpr := sweeper.New(db, skydClientMock, cfg.ServerName)
+	swpr := sweeper.New(db, skydClientMock, cfg.ServerName, logger)
 	// The server API encapsulates all the modules together.
 	server, err := api.New(cfg.ServerName, db, logger, skydClientMock, swpr)
 	if err != nil {

--- a/test/tester.go
+++ b/test/tester.go
@@ -14,6 +14,7 @@ import (
 	"github.com/skynetlabs/pinner/api"
 	"github.com/skynetlabs/pinner/database"
 	"github.com/skynetlabs/pinner/skyd"
+	"github.com/skynetlabs/pinner/sweeper"
 	"gitlab.com/NebulousLabs/errors"
 	"gitlab.com/SkynetLabs/skyd/build"
 )
@@ -68,8 +69,9 @@ func NewTester(dbName string) (*Tester, error) {
 
 	ctxWithCancel, cancel := context.WithCancel(ctx)
 	skydClientMock := skyd.NewSkydClientMock()
+	swpr := sweeper.New(db, skydClientMock, cfg.ServerName)
 	// The server API encapsulates all the modules together.
-	server, err := api.New(cfg.ServerName, db, logger, skydClientMock)
+	server, err := api.New(cfg.ServerName, db, logger, skydClientMock, swpr)
 	if err != nil {
 		cancel()
 		return nil, errors.AddContext(err, "failed to build the API")
@@ -295,8 +297,8 @@ func (t *Tester) SweepPOST() (api.SweepPOSTResponse, int, error) {
 }
 
 // SweepStatusGET returns the status of the latest sweep.
-func (t *Tester) SweepStatusGET() (api.SweepStatus, int, error) {
-	var resp api.SweepStatus
+func (t *Tester) SweepStatusGET() (sweeper.Status, int, error) {
+	var resp sweeper.Status
 	r, err := t.Request(http.MethodGet, "/sweep/status", nil, nil, nil, &resp)
 	return resp, r.StatusCode, err
 }

--- a/workers/scanner.go
+++ b/workers/scanner.go
@@ -27,11 +27,11 @@ import (
 	- pin it locally and add the current server to its list
 	- unlock it
 
- PHASE 2:
+ PHASE 2: <TODO>
  - calculate server load by getting the total number and size of files pinned by each server
  - only pin underpinned files if the current server is in the lowest 20% of servers, otherwise exit before scanning further
 
- PHASE 3:
+ PHASE 3: <TODO>
  - add a second scanner which looks for skylinks which should be unpinned and unpins them from the local skyd.
 */
 

--- a/workers/scanner.go
+++ b/workers/scanner.go
@@ -245,7 +245,7 @@ func (s *Scanner) managedFindAndPinOneUnderpinnedSkylink() (skylink skymodules.S
 	if errors.Contains(err, skyd.ErrSkylinkAlreadyPinned) {
 		s.staticLogger.Info(err)
 		// The skylink is already pinned locally but it's not marked as such.
-		err = s.staticDB.AddServerForSkylink(context.TODO(), sl, s.staticServerName, false)
+		err = s.staticDB.AddServerForSkylinks(context.TODO(), []string{sl.String()}, s.staticServerName, false)
 		if err != nil {
 			s.staticLogger.Debug(errors.AddContext(err, "failed to mark as pinned by this server"))
 		}
@@ -264,7 +264,7 @@ func (s *Scanner) managedFindAndPinOneUnderpinnedSkylink() (skylink skymodules.S
 		return skymodules.Skylink{}, skymodules.SiaPath{}, true, err
 	}
 	s.staticLogger.Infof("Successfully pinned '%s'", sl)
-	err = s.staticDB.AddServerForSkylink(context.TODO(), sl, s.staticServerName, false)
+	err = s.staticDB.AddServerForSkylinks(context.TODO(), []string{sl.String()}, s.staticServerName, false)
 	if err != nil {
 		s.staticLogger.Debug(errors.AddContext(err, "failed to mark as pinned by this server"))
 	}

--- a/workers/scanner_test.go
+++ b/workers/scanner_test.go
@@ -20,11 +20,6 @@ const (
 	cyclesToWait = 5
 )
 
-var (
-	// maxSleepBetweenScans is the maximum time we might sleep between scans.
-	maxSleepBetweenScans = time.Duration(float64(sleepBetweenScans) * (1 + sleepVariationFactor))
-)
-
 // TestScanner ensures that Scanner does its job.
 func TestScanner(t *testing.T) {
 	if testing.Short() {

--- a/workers/scanner_test.go
+++ b/workers/scanner_test.go
@@ -69,7 +69,7 @@ func TestScanner(t *testing.T) {
 		t.Fatal("We didn't expect skyd to be pinning this.")
 	}
 	// Remove the other server, making the file underpinned.
-	err = db.RemoveServerFromSkylink(ctx, sl, otherServer)
+	err = db.RemoveServerFromSkylinks(ctx, []string{sl.String()}, otherServer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestScannerDryRun(t *testing.T) {
 		t.Fatal("We didn't expect skyd to be pinning this.")
 	}
 	// Remove the other server, making the file underpinned.
-	err = db.RemoveServerFromSkylink(ctx, sl, otherServer)
+	err = db.RemoveServerFromSkylinks(ctx, []string{sl.String()}, otherServer)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# PULL REQUEST

## Overview

Implement a sweeping schedule. This will help Pinner stay up to date with all files pinned by the servers, even if nginx fails to notify it. This is only a backup measure but it's rather useful.

The sweeps are very slow if there is a lot to sweep but they are very quick if there isn't. I don't expect this to put any measurable additional pressure on the servers.

## Example for Visual Changes

<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [ ] All git commits are signed. (REQUIRED)
- [ ] All new methods or updated methods have clear docstrings.
- [ ] Testing added or updated for new methods.
- [ ] Verified if any changes impact the WebPortal Health Checks.
- [ ] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed
Closes SKY-1101
