### PR TITLE
Mark server as dead/removed

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -6,6 +6,7 @@ func (api *API) buildHTTPRoutes() {
 
 	api.staticRouter.POST("/pin", api.pinPOST)
 	api.staticRouter.POST("/unpin", api.unpinPOST)
+	api.staticRouter.POST("/server/remove", api.serverRemovePOST)
 	api.staticRouter.POST("/sweep", api.sweepPOST)
 	api.staticRouter.GET("/sweep/status", api.sweepStatusGET)
 }

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -141,6 +141,21 @@ func (db *DB) AddServerForSkylinks(ctx context.Context, skylinks []string, serve
 	return err
 }
 
+// RemoveServer removes the server as pinner from all skylinks in the database.
+// Returns the number of skylinks from which the server was removed as pinner.
+func (db *DB) RemoveServer(ctx context.Context, server string) (int64, error) {
+	filter := bson.M{"servers": server}
+	update := bson.M{"$pull": bson.M{"servers": server}}
+	ur, err := db.staticDB.Collection(collSkylinks).UpdateMany(ctx, filter, update)
+	if errors.Contains(err, mongo.ErrNoDocuments) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return ur.ModifiedCount, nil
+}
+
 // RemoveServerFromSkylinks removes a server from the list of servers known to
 // be pinning these skylinks. If a skylink does not exist in the database it
 // will not be inserted.

--- a/test/api/handlers_test.go
+++ b/test/api/handlers_test.go
@@ -43,6 +43,7 @@ func TestHandlers(t *testing.T) {
 		{name: "Health", test: testHandlerHealthGET},
 		{name: "Pin", test: testHandlerPinPOST},
 		{name: "Unpin", test: testHandlerUnpinPOST},
+		{name: "ServerRemove", test: testServerRemovePOST},
 		{name: "Sweep", test: testHandlerSweep},
 	}
 
@@ -158,6 +159,64 @@ func testHandlerUnpinPOST(t *testing.T, tt *test.Tester) {
 	}
 	if sl2New.Pinned {
 		t.Fatal("Expected the skylink to be marked as unpinned.")
+	}
+}
+
+// testServerRemovePOST tests "POST /server/remove"
+func testServerRemovePOST(t *testing.T, tt *test.Tester) {
+	sl1 := test.RandomSkylink()
+	sl2 := test.RandomSkylink()
+	server := t.Name()
+
+	// Pass empty server name.
+	_, _, err := tt.ServerRemovePOST("")
+	if err == nil || !strings.Contains(err.Error(), "no server found in request body") {
+		t.Fatalf("Expected '%s', got '%s'", "no server found in request body", err)
+	}
+	// Remove a non-existent server. Expect no error, zero skylinks.
+	r, status, err := tt.ServerRemovePOST(server)
+	if err != nil || status != http.StatusOK || r.NumSkylinks != 0 {
+		t.Fatalf("Expected no error, status 200, and zero skylinks affected, got error '%v', status %d and %d skylinks afffected", err, status, r.NumSkylinks)
+	}
+	// Create skylinks and mark them as pinned by the server.
+	_, err = tt.DB.CreateSkylink(tt.Ctx, sl1, server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tt.DB.CreateSkylink(tt.Ctx, sl2, server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Remove the server.
+	r, status, err = tt.ServerRemovePOST(server)
+	if err != nil || status != http.StatusOK {
+		t.Fatal(status, err)
+	}
+	// Make sure the response mentions two skylinks.
+	if r.NumSkylinks != 2 {
+		t.Fatalf("Expected 2 skylinks affected, got %d", r.NumSkylinks)
+	}
+	// Make sure the server is no longer marked as pinner for those two skylinks.
+	foundSl, err := tt.DB.FindSkylink(tt.Ctx, sl1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if foundSl.Skylink != sl1.String() {
+		t.Fatal("Unexpected skylink.")
+	}
+	if test.Contains(foundSl.Servers, server) {
+		t.Fatalf("Expected to not find '%s' in servers list, got '%v'", server, foundSl.Servers)
+	}
+	// Same for the second skylink.
+	foundSl, err = tt.DB.FindSkylink(tt.Ctx, sl2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if foundSl.Skylink != sl2.String() {
+		t.Fatal("Unexpected skylink.")
+	}
+	if test.Contains(foundSl.Servers, server) {
+		t.Fatalf("Expected to not find '%s' in servers list, got '%v'", server, foundSl.Servers)
 	}
 }
 

--- a/test/api/handlers_test.go
+++ b/test/api/handlers_test.go
@@ -192,6 +192,16 @@ func testServerRemovePOST(t *testing.T, tt *test.Tester) {
 	if err != nil || status != http.StatusOK {
 		t.Fatal(status, err)
 	}
+	// Make sure there's a scan scheduled for about an hour later.
+	t0, err := conf.NextScan(tt.Ctx, tt.DB, tt.Logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	timeTarget := time.Now().UTC().Add(time.Hour)
+	tolerance := time.Minute
+	if t0.Before(timeTarget.Add(-1*tolerance)) || t0.After(timeTarget.Add(tolerance)) {
+		t.Fatalf("Expected the next scan to be in one hour (%s), got %s", timeTarget.String(), t0.String())
+	}
 	// Make sure the response mentions two skylinks.
 	if r.NumSkylinks != 2 {
 		t.Fatalf("Expected 2 skylinks affected, got %d", r.NumSkylinks)

--- a/test/tester.go
+++ b/test/tester.go
@@ -213,6 +213,16 @@ func (t *Tester) SetFollowRedirects(f bool) {
 	t.FollowRedirects = f
 }
 
+// ServerRemovePOST removes a server as pinner.
+func (t *Tester) ServerRemovePOST(server string) (api.ServerRemoveResponse, int, error) {
+	body, err := json.Marshal(api.ServerRemoveRequest{
+		Server: server,
+	})
+	var resp api.ServerRemoveResponse
+	r, err := t.Request(http.MethodPost, "/server/remove", nil, body, nil, &resp)
+	return resp, r.StatusCode, err
+}
+
 // SweepPOST kicks off a background process which gets all files pinned by skyd
 // and marks them in the DB as pinned by the current server. It also goes over
 // all files in the DB that are marked as pinned by the local skyd and unmarks


### PR DESCRIPTION

# PULL REQUEST

## Overview

This PR adds a new endpoint which removes a server from the cluster, a.k.a. marks it as dead. This causes the server to be removed as pinner from all skylink it was previously pinning. Also, a new scan is scheduled for an hour later, so we can start repinning all those freshly underpinned skylinks on other servers.

## Example for Visual Changes

<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [ ] All git commits are signed. (REQUIRED)
- [ ] All new methods or updated methods have clear docstrings.
- [ ] Testing added or updated for new methods.
- [ ] Verified if any changes impact the WebPortal Health Checks.
- [ ] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed

Closes SKY-297
