### PR TITLE
Limit repinning underpinned skylinks to underutilized servers

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"github.com/skynetlabs/pinner/lib"
 	"net/http"
 	"time"
 
@@ -123,7 +124,7 @@ func (api *API) serverRemovePOST(w http.ResponseWriter, req *http.Request, _ htt
 	// Schedule a scan for underpinned skylinks in an hour (unless one is
 	// already pending), so all of them can be repinned ASAP but also all
 	// servers in the cluster will have enough time to get the memo for the scan.
-	t := time.Now().UTC().Add(time.Hour)
+	t := lib.Now().Add(time.Hour)
 	t0, err := conf.NextScan(ctx, api.staticDB, api.staticLogger)
 	// We just set it when we encounter an error because we can get such an
 	// error in two cases - there is no next scan scheduled or there is a

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -63,7 +63,7 @@ const (
 
 const (
 	// TimeFormat defines the time format we'll use throughout the service.
-	TimeFormat = time.RFC3339
+	TimeFormat = time.RFC3339Nano
 )
 
 var (

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -248,7 +248,7 @@ func NextScan(ctx context.Context, db *database.DB, logger logger.Logger) (time.
 	if errors.Contains(err, mongo.ErrNoDocuments) {
 		logger.Infof("Missing database value for '%s', setting a new one.", ConfNextScan)
 		// No scan has been scheduled. Schedule one in an hour.
-		scanTime := time.Now().Add(DefaultNextScanOffset).UTC()
+		scanTime := time.Now().UTC().Add(DefaultNextScanOffset).Truncate(time.Millisecond)
 		err = SetNextScan(ctx, db, scanTime)
 		if err != nil {
 			return time.Time{}, err
@@ -264,14 +264,14 @@ func NextScan(ctx context.Context, db *database.DB, logger logger.Logger) (time.
 		logger.Error(errMsg)
 		build.Critical(errors.AddContext(err, "potential programmer error"))
 		// The values in the database is unusable. Schedule a scan in an hour.
-		scanTime := time.Now().Add(DefaultNextScanOffset).UTC()
+		scanTime := time.Now().UTC().Add(DefaultNextScanOffset).Truncate(time.Millisecond)
 		err = SetNextScan(ctx, db, scanTime)
 		if err != nil {
 			return time.Time{}, err
 		}
 		return scanTime, nil
 	}
-	return t, nil
+	return t.UTC().Truncate(time.Millisecond), nil
 }
 
 // SetNextScan sets the time of the next cluster-wide scan for underpinned files.

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -3,6 +3,7 @@ package conf
 import (
 	"context"
 	"fmt"
+	"github.com/skynetlabs/pinner/lib"
 	"log"
 	"os"
 	"strconv"
@@ -248,7 +249,7 @@ func NextScan(ctx context.Context, db *database.DB, logger logger.Logger) (time.
 	if errors.Contains(err, mongo.ErrNoDocuments) {
 		logger.Infof("Missing database value for '%s', setting a new one.", ConfNextScan)
 		// No scan has been scheduled. Schedule one in an hour.
-		scanTime := time.Now().UTC().Add(DefaultNextScanOffset).Truncate(time.Millisecond)
+		scanTime := lib.Now().Add(DefaultNextScanOffset)
 		err = SetNextScan(ctx, db, scanTime)
 		if err != nil {
 			return time.Time{}, err
@@ -264,7 +265,7 @@ func NextScan(ctx context.Context, db *database.DB, logger logger.Logger) (time.
 		logger.Error(errMsg)
 		build.Critical(errors.AddContext(err, "potential programmer error"))
 		// The values in the database is unusable. Schedule a scan in an hour.
-		scanTime := time.Now().UTC().Add(DefaultNextScanOffset).Truncate(time.Millisecond)
+		scanTime := lib.Now().Add(DefaultNextScanOffset)
 		err = SetNextScan(ctx, db, scanTime)
 		if err != nil {
 			return time.Time{}, err
@@ -276,7 +277,7 @@ func NextScan(ctx context.Context, db *database.DB, logger logger.Logger) (time.
 
 // SetNextScan sets the time of the next cluster-wide scan for underpinned files.
 func SetNextScan(ctx context.Context, db *database.DB, t time.Time) error {
-	if t.Before(time.Now().UTC().Add(SleepBetweenChecksForScan)) {
+	if t.Before(lib.Now().Add(SleepBetweenChecksForScan)) {
 		return ErrTimeTooSoon
 	}
 	return db.SetConfigValue(ctx, ConfNextScan, t.UTC().Format(TimeFormat))

--- a/database/database.go
+++ b/database/database.go
@@ -30,6 +30,10 @@ var (
 	// collConfig defines the name of the collection which will hold the
 	// cluster-wide service configuration.
 	collConfig = "configuration"
+	// collServerLoad defines the name of the collection which will hold
+	// information about each server's load in terms of amount of data it's
+	// pinning
+	collServerLoad = "server_load"
 	// collSkylinks defines the name of the collection which will hold
 	// information about skylinks
 	collSkylinks = "skylinks"

--- a/database/schema.go
+++ b/database/schema.go
@@ -14,6 +14,22 @@ import (
 // databases and are iterating over the schema at the same time.
 func schema() map[string][]mongo.IndexModel {
 	return map[string][]mongo.IndexModel{
+		collConfig: {
+			{
+				Keys:    bson.D{{"key", 1}},
+				Options: options.Index().SetName("key").SetUnique(true),
+			},
+		},
+		collServerLoad: {
+			{
+				Keys:    bson.D{{"server_name", 1}},
+				Options: options.Index().SetName("server_name").SetUnique(true),
+			},
+			{
+				Keys:    bson.D{{"load", 1}},
+				Options: options.Index().SetName("load"),
+			},
+		},
 		collSkylinks: {
 			{
 				Keys:    bson.D{{"skylink", 1}},
@@ -34,12 +50,6 @@ func schema() map[string][]mongo.IndexModel {
 			{
 				Keys:    bson.D{{"pinned", 1}},
 				Options: options.Index().SetName("pinned"),
-			},
-		},
-		collConfig: {
-			{
-				Keys:    bson.D{{"key", 1}},
-				Options: options.Index().SetName("key").SetUnique(true),
 			},
 		},
 	}

--- a/database/serverload.go
+++ b/database/serverload.go
@@ -1,0 +1,85 @@
+package database
+
+import (
+	"context"
+	"gitlab.com/NebulousLabs/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+var (
+	// ErrServerLoadNotFound is returned when we don't have a record for the
+	// server's load.
+	ErrServerLoadNotFound = errors.New("server load not found")
+)
+
+// ServerLoad returns the server load stored in the database.
+func (db *DB) ServerLoad(ctx context.Context, server string) (int64, error) {
+	filter := bson.M{"server_name": server}
+	sr := db.staticDB.Collection(collServerLoad).FindOne(ctx, filter)
+	if sr.Err() == mongo.ErrNoDocuments {
+		return 0, ErrServerLoadNotFound
+	}
+	if sr.Err() != nil {
+		return 0, sr.Err()
+	}
+	res := struct {
+		Load int64
+	}{}
+	err := sr.Decode(&res)
+	if err != nil {
+		return 0, err
+	}
+	return res.Load, nil
+}
+
+// ServerLoadPosition returns the position of the server in the list of servers
+// based on its load. It also returns the total number of servers.
+func (db *DB) ServerLoadPosition(ctx context.Context, server string) (int, int, error) {
+	// Fetch all server loads, order by load in descending order.
+	opts := &options.FindOptions{
+		Sort: bson.M{"load": -1},
+	}
+	c, err := db.staticDB.Collection(collServerLoad).Find(ctx, bson.M{}, opts)
+	if err != nil {
+		return 0, 0, err
+	}
+	found := false
+	position := 0
+	cur := struct {
+		ServerName string `bson:"server_name"`
+		Load       int64  `bson:"load"`
+	}{}
+	// Loop over all server loads until we find the one we need.
+	for c.Next(ctx) {
+		err = c.Decode(&cur)
+		if err != nil {
+			return 0, 0, err
+		}
+		if cur.ServerName == server {
+			found = true
+			break
+		}
+		position++
+	}
+	if found {
+		return position, position + 1 + c.RemainingBatchLength(), nil
+	}
+	return 0, 0, ErrServerLoadNotFound
+}
+
+// SetServerLoad stores the load of this server in the database.
+func (db *DB) SetServerLoad(ctx context.Context, server string, load int64) error {
+	if server == "" {
+		return errors.New("invalid server name")
+	}
+	filter := bson.M{"server_name": server}
+	update := bson.M{"$set": bson.M{
+		"server_name": server,
+		"load":        load,
+	}}
+	opts := options.Update().SetUpsert(true)
+	_, err := db.staticDB.Collection(collServerLoad).UpdateOne(ctx, filter, update, opts)
+	return err
+}

--- a/database/serverload.go
+++ b/database/serverload.go
@@ -14,6 +14,17 @@ var (
 	ErrServerLoadNotFound = errors.New("server load not found")
 )
 
+// DeleteServerLoad removes the load info for this server. We should use this
+// when we mark a server as dead.
+func (db *DB) DeleteServerLoad(ctx context.Context, server string) error {
+	filter := bson.M{"server_name": server}
+	dr, err := db.staticDB.Collection(collServerLoad).DeleteOne(ctx, filter)
+	if err == mongo.ErrNoDocuments || dr.DeletedCount == 0 {
+		return ErrServerLoadNotFound
+	}
+	return nil
+}
+
 // ServerLoad returns the server load stored in the database.
 func (db *DB) ServerLoad(ctx context.Context, server string) (int64, error) {
 	filter := bson.M{"server_name": server}

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"github.com/skynetlabs/pinner/lib"
 	"time"
 
 	"gitlab.com/NebulousLabs/errors"
@@ -197,13 +198,13 @@ func (db *DB) FindAndLockUnderpinned(ctx context.Context, server string, minPinn
 		// Unlocked.
 		"$or": bson.A{
 			bson.M{"lock_expires": bson.M{"$exists": false}},
-			bson.M{"lock_expires": bson.M{"$lt": time.Now().UTC().Truncate(time.Millisecond)}},
+			bson.M{"lock_expires": bson.M{"$lt": lib.Now()}},
 		},
 	}
 	update := bson.M{
 		"$set": bson.M{
 			"locked_by":    server,
-			"lock_expires": time.Now().UTC().Add(LockDuration).Truncate(time.Millisecond),
+			"lock_expires": lib.Now().Add(LockDuration),
 		},
 	}
 	opts := options.FindOneAndUpdate().SetReturnDocument(options.After)

--- a/database/units.go
+++ b/database/units.go
@@ -1,0 +1,12 @@
+package database
+
+const (
+	// KiB kilobyte
+	KiB = 1024
+	// MiB megabyte
+	MiB = 1024 * KiB
+	// GiB gigabyte
+	GiB = 1024 * MiB
+	// TiB terabyte
+	TiB = 1024 * GiB
+)

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -1,0 +1,8 @@
+package lib
+
+import "time"
+
+// Now returns the current time in UTC, truncated to milliseconds.
+func Now() time.Time {
+	return time.Now().UTC().Truncate(time.Millisecond)
+}

--- a/skyd/mock.go
+++ b/skyd/mock.go
@@ -12,6 +12,7 @@ import (
 type (
 	// ClientMock is a mock of skyd.Client
 	ClientMock struct {
+		contractData   uint64
 		fileHealth     map[skymodules.SiaPath]float64
 		filesystemMock map[skymodules.SiaPath]rdReturnType
 		metadata       map[string]skymodules.SkyfileMetadata
@@ -39,6 +40,16 @@ func NewSkydClientMock() *ClientMock {
 		metadataErrors: make(map[string]error),
 		skylinks:       make(map[string]struct{}),
 	}
+}
+
+// ContractData returns the total data from Active and Passive contracts.
+func (c *ClientMock) ContractData() (uint64, error) {
+	return c.contractData, nil
+}
+
+// SetContractData sets the contract data value returned by the mock.
+func (c *ClientMock) SetContractData(n uint64) {
+	c.contractData = n
 }
 
 // DiffPinnedSkylinks is a carbon copy of PinnedSkylinksCache's version of the

--- a/skyd/mock.go
+++ b/skyd/mock.go
@@ -44,11 +44,15 @@ func NewSkydClientMock() *ClientMock {
 
 // ContractData returns the total data from Active and Passive contracts.
 func (c *ClientMock) ContractData() (uint64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.contractData, nil
 }
 
 // SetContractData sets the contract data value returned by the mock.
 func (c *ClientMock) SetContractData(n uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.contractData = n
 }
 

--- a/skyd/skyd.go
+++ b/skyd/skyd.go
@@ -22,6 +22,8 @@ var (
 type (
 	// Client describes the interface exposed by client.
 	Client interface {
+		// ContractData returns the total data from Active and Passive contracts.
+		ContractData() (uint64, error)
 		// DiffPinnedSkylinks returns two lists of skylinks - the ones that
 		// belong to the given list but are not pinned by skyd (unknown) and the
 		// ones that are pinned by skyd but are not on the list (missing).
@@ -66,6 +68,22 @@ func NewClient(host, port, password string, cache *PinnedSkylinksCache, logger l
 		staticLogger:        logger,
 		staticSkylinksCache: cache,
 	}
+}
+
+// ContractData returns the total data from Active and Passive contracts.
+func (c *client) ContractData() (uint64, error) {
+	rcs, err := c.staticClient.RenterContractsGet()
+	if err != nil {
+		return 0, err
+	}
+	data := uint64(0)
+	for _, ctr := range rcs.ActiveContracts {
+		data += ctr.Size
+	}
+	for _, ctr := range rcs.PassiveContracts {
+		data += ctr.Size
+	}
+	return data, nil
 }
 
 // DiffPinnedSkylinks returns two lists of skylinks - the ones that belong to

--- a/sweeper/status.go
+++ b/sweeper/status.go
@@ -1,6 +1,7 @@
 package sweeper
 
 import (
+	"github.com/skynetlabs/pinner/lib"
 	"github.com/skynetlabs/pinner/logger"
 	"sync"
 	"time"
@@ -36,7 +37,7 @@ func (st *status) Start() {
 	// Initialise the status to "a sweep is running".
 	st.status.InProgress = true
 	st.status.Error = nil
-	st.status.StartTime = time.Now().UTC()
+	st.status.StartTime = lib.Now()
 	st.status.EndTime = time.Time{}
 	st.mu.Unlock()
 	st.staticLogger.Info("Started a sweep.")
@@ -58,7 +59,7 @@ func (st *status) Finalize(err error) {
 		return
 	}
 	st.status.InProgress = false
-	st.status.EndTime = time.Now().UTC()
+	st.status.EndTime = lib.Now()
 	st.status.Error = err
 	st.mu.Unlock()
 	st.staticLogger.Info("Finalized a sweep.")

--- a/sweeper/status_test.go
+++ b/sweeper/status_test.go
@@ -2,6 +2,7 @@ package sweeper
 
 import (
 	"github.com/sirupsen/logrus"
+	"github.com/skynetlabs/pinner/lib"
 	"gitlab.com/NebulousLabs/errors"
 	"io/ioutil"
 	"testing"
@@ -36,7 +37,7 @@ func TestStatus(t *testing.T) {
 	// Start and verify.
 	s.Start()
 	st = s.Status()
-	if !st.InProgress || st.StartTime.After(time.Now().UTC()) {
+	if !st.InProgress || st.StartTime.After(lib.Now()) {
 		t.Fatalf("Unexpected status: %+v", st)
 	}
 	// Store the start time and verify that attempting to start again will not

--- a/sweeper/sweeper.go
+++ b/sweeper/sweeper.go
@@ -2,6 +2,7 @@ package sweeper
 
 import (
 	"context"
+	"github.com/skynetlabs/pinner/lib"
 	"time"
 
 	"github.com/skynetlabs/pinner/database"
@@ -88,7 +89,7 @@ func (s *Sweeper) threadedPerformSweep() {
 	// specific API call. Also, this operation can take a significant amount of
 	// time and we don't want it to fail because of a timeout.
 	ctx := context.Background()
-	dbCtx, cancel := context.WithDeadline(ctx, time.Now().UTC().Add(database.MongoDefaultTimeout))
+	dbCtx, cancel := context.WithDeadline(ctx, lib.Now().Add(database.MongoDefaultTimeout))
 	defer cancel()
 
 	// Get pinned skylinks from the DB

--- a/test/api/handlers_test.go
+++ b/test/api/handlers_test.go
@@ -202,9 +202,11 @@ func testServerRemovePOST(t *testing.T, tt *test.Tester) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	timeTarget := time.Now().UTC().Add(time.Hour)
-	tolerance := time.Minute
-	if t0.Before(timeTarget.Add(-1*tolerance)) || t0.After(timeTarget.Add(tolerance)) {
+	timeTarget := time.Now().UTC().Add(time.Hour).Truncate(time.Millisecond)
+	tolerance := time.Minute.Truncate(time.Millisecond)
+	low := timeTarget.Add(-1 * tolerance).Truncate(time.Millisecond)
+	high := timeTarget.Add(tolerance).Truncate(time.Millisecond)
+	if t0.Before(low) || t0.After(high) {
 		t.Fatalf("Expected the next scan to be in one hour (%s), got %s", timeTarget.String(), t0.String())
 	}
 	// Make sure the response mentions two skylinks.

--- a/test/api/handlers_test.go
+++ b/test/api/handlers_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"github.com/skynetlabs/pinner/lib"
 	"net/http"
 	"strconv"
 	"strings"
@@ -187,7 +188,7 @@ func testServerRemovePOST(t *testing.T, tt *test.Tester) {
 		t.Fatal(err)
 	}
 	// Set the next scan to be in 24 hours before removing the server.
-	err = conf.SetNextScan(tt.Ctx, tt.DB, time.Now().UTC().Add(24*time.Hour))
+	err = conf.SetNextScan(tt.Ctx, tt.DB, lib.Now().Add(24*time.Hour))
 	// Remove the server.
 	r, status, err = tt.ServerRemovePOST(server)
 	if err != nil || status != http.StatusOK {
@@ -203,7 +204,7 @@ func testServerRemovePOST(t *testing.T, tt *test.Tester) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	timeTarget := time.Now().UTC().Add(time.Hour).Truncate(time.Millisecond)
+	timeTarget := lib.Now().Add(time.Hour)
 	tolerance := time.Minute.Truncate(time.Millisecond)
 	low := timeTarget.Add(-1 * tolerance).Truncate(time.Millisecond)
 	high := timeTarget.Add(tolerance).Truncate(time.Millisecond)
@@ -267,7 +268,7 @@ func testHandlerSweep(t *testing.T, tt *test.Tester) {
 		t.Fatalf("Unexpected sweep detected: %+v", sweepStatus)
 	}
 	// Start a sweep. Expect to return immediately with a 202.
-	sweepReqTime := time.Now().UTC()
+	sweepReqTime := lib.Now()
 	sr, code, err := tt.SweepPOST()
 	if err != nil || code != http.StatusAccepted {
 		t.Fatalf("Unexpected status code or error: %d %+v", code, err)
@@ -278,7 +279,7 @@ func testHandlerSweep(t *testing.T, tt *test.Tester) {
 	// Make sure that the call returned quickly, i.e. it didn't wait for the
 	// sweep to end but rather returned immediately and let the sweep run in the
 	// background. Rebuilding the cache alone takes 100ms.
-	if time.Now().UTC().Add(-50 * time.Millisecond).After(sweepReqTime) {
+	if lib.Now().Add(-50 * time.Millisecond).After(sweepReqTime) {
 		t.Fatal("Call to status took too long.")
 	}
 	// Check status. Expect a sweep in progress.

--- a/test/api/handlers_test.go
+++ b/test/api/handlers_test.go
@@ -192,6 +192,11 @@ func testServerRemovePOST(t *testing.T, tt *test.Tester) {
 	if err != nil || status != http.StatusOK {
 		t.Fatal(status, err)
 	}
+	// Make sure the server's load record is gone.
+	_, err = tt.DB.ServerLoad(tt.Ctx, server)
+	if !errors.Contains(err, database.ErrServerLoadNotFound) {
+		t.Fatalf("Expected '%v', got '%v'", database.ErrServerLoadNotFound, err)
+	}
 	// Make sure there's a scan scheduled for about an hour later.
 	t0, err := conf.NextScan(tt.Ctx, tt.DB, tt.Logger)
 	if err != nil {

--- a/test/api/handlers_test.go
+++ b/test/api/handlers_test.go
@@ -26,7 +26,6 @@ func TestHandlers(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	tt, err := test.NewTester(t.Name())
 	if err != nil {
@@ -187,6 +186,8 @@ func testServerRemovePOST(t *testing.T, tt *test.Tester) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Set the next scan to be in 24 hours before removing the server.
+	err = conf.SetNextScan(tt.Ctx, tt.DB, time.Now().UTC().Add(24*time.Hour))
 	// Remove the server.
 	r, status, err = tt.ServerRemovePOST(server)
 	if err != nil || status != http.StatusOK {

--- a/test/conf/configuration_test.go
+++ b/test/conf/configuration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/skynetlabs/pinner/conf"
 	"github.com/skynetlabs/pinner/database"
+	"github.com/skynetlabs/pinner/lib"
 	"github.com/skynetlabs/pinner/test"
 	"gitlab.com/NebulousLabs/errors"
 	"gitlab.com/NebulousLabs/fastrand"
@@ -169,19 +170,19 @@ func testNextScan(t *testing.T, db *database.DB) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	now := time.Now().UTC()
+	now := lib.Now()
 	tolerance := 5 * time.Second
 	if t0.After(now.Add(tolerance)) || t0.Before(now.Add(-1*tolerance)) {
 		t.Fatalf("Expected roughly '%s', got '%s'", now.Add(conf.DefaultNextScanOffset), t0)
 	}
 	// Try to set an invalid value.
-	err = conf.SetNextScan(ctx, db, time.Now().UTC().Add(-1*time.Hour))
+	err = conf.SetNextScan(ctx, db, lib.Now().Add(-1*time.Hour))
 	if !errors.Contains(err, conf.ErrTimeTooSoon) {
 		t.Fatalf("Expected '%s', got '%s'", conf.ErrTimeTooSoon, err)
 	}
 	// Set a valid value.
 	// Truncate to second because RFC3339 doesn't represent less than that.
-	t1 := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	t1 := lib.Now().Add(time.Hour).Truncate(time.Second)
 	err = conf.SetNextScan(ctx, db, t1)
 	if err != nil {
 		t.Fatal(err)

--- a/test/conf/configuration_test.go
+++ b/test/conf/configuration_test.go
@@ -181,8 +181,7 @@ func testNextScan(t *testing.T, db *database.DB) {
 		t.Fatalf("Expected '%s', got '%s'", conf.ErrTimeTooSoon, err)
 	}
 	// Set a valid value.
-	// Truncate to second because RFC3339 doesn't represent less than that.
-	t1 := lib.Now().Add(time.Hour).Truncate(time.Second)
+	t1 := lib.Now().Add(time.Hour).Truncate(time.Millisecond)
 	err = conf.SetNextScan(ctx, db, t1)
 	if err != nil {
 		t.Fatal(err)

--- a/test/database/serverload_test.go
+++ b/test/database/serverload_test.go
@@ -1,0 +1,89 @@
+package database
+
+import (
+	"encoding/hex"
+	"github.com/skynetlabs/pinner/database"
+	"github.com/skynetlabs/pinner/test"
+	"gitlab.com/NebulousLabs/errors"
+	"gitlab.com/NebulousLabs/fastrand"
+	"math"
+	"testing"
+)
+
+// TestServerLoad ensures that we can correctly set and get the load of servers,
+// as well as fetch their correct positions in the list of servers ordered by
+// load.
+func TestServerLoad(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	ctx, cancel := test.Context()
+	defer cancel()
+	db, err := test.NewDatabase(ctx, t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server1 := hex.EncodeToString(fastrand.Bytes(16))
+	server2 := hex.EncodeToString(fastrand.Bytes(16))
+	load1 := int64(fastrand.Intn(math.MaxInt))
+	load2 := int64(fastrand.Intn(math.MaxInt))
+	if load1 == load2 {
+		load2++
+	}
+	var pos1, pos2 int
+	if load1 > load2 {
+		pos1 = 0
+		pos2 = 1
+	} else {
+		pos1 = 1
+		pos2 = 0
+	}
+
+	// Get the load of a non-existent server. Expect ErrServerLoadNotFound.
+	_, err = db.ServerLoad(ctx, "non-existent")
+	if !errors.Contains(err, database.ErrServerLoadNotFound) {
+		t.Fatalf("Expected '%s', got '%v'", database.ErrServerLoadNotFound, err)
+	}
+	// Set the server load of two servers.
+	err = db.SetServerLoad(ctx, server1, load1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = db.SetServerLoad(ctx, server2, load2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Get the loads.
+	l1, err := db.ServerLoad(ctx, server1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l1 != load1 {
+		t.Fatalf("Expected load of %d, got %d", load1, l1)
+	}
+	l2, err := db.ServerLoad(ctx, server2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l2 != load2 {
+		t.Fatalf("Expected load of %d, got %d", load2, l2)
+	}
+	// Get the positions of the two servers.
+	p1, total, err := db.ServerLoadPosition(ctx, server1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1 != pos1 || total != 2 {
+		t.Fatalf("Expected position %d of %d, got %d of %d", pos1, 2, p1, total)
+	}
+	p2, total, err := db.ServerLoadPosition(ctx, server2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p2 != pos2 || total != 2 {
+		t.Fatalf("Expected position %d of %d, got %d of %d", pos2, 2, p2, total)
+	}
+}

--- a/test/database/serverload_test.go
+++ b/test/database/serverload_test.go
@@ -86,4 +86,18 @@ func TestServerLoad(t *testing.T) {
 	if p2 != pos2 || total != 2 {
 		t.Fatalf("Expected position %d of %d, got %d of %d", pos2, 2, p2, total)
 	}
+	// Delete a non-existent server.
+	err = db.DeleteServerLoad(ctx, "non-existent")
+	if !errors.Contains(err, database.ErrServerLoadNotFound) {
+		t.Fatalf("Expected '%v', got '%v'", database.ErrServerLoadNotFound, err)
+	}
+	err = db.DeleteServerLoad(ctx, server1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make sure we can't fetch any data for it.
+	_, err = db.ServerLoad(ctx, server1)
+	if !errors.Contains(err, database.ErrServerLoadNotFound) {
+		t.Fatalf("Expected '%s', got '%v'", database.ErrServerLoadNotFound, err)
+	}
 }

--- a/workers/scanner.go
+++ b/workers/scanner.go
@@ -27,9 +27,10 @@ import (
 	- pin it locally and add the current server to its list
 	- unlock it
 
- PHASE 2: <TODO>
- - calculate server load by getting the total number and size of files pinned by each server
- - only pin underpinned files if the current server is in the lowest 20% of servers, otherwise exit before scanning further
+ PHASE 2: <DONE>
+ - calculate server load by getting the total size of files pinned by each server
+ - only pin underpinned files if the current server is in the lowest 30% of servers, otherwise exit before scanning further
+ - always pin if this server is lowest in the list (covers setups with up to 3 servers)
 
  PHASE 3: <TODO>
  - add a second scanner which looks for skylinks which should be unpinned and unpins them from the local skyd.
@@ -43,6 +44,19 @@ const (
 )
 
 var (
+	// AlwaysPinThreshold sets a limit on the contract data of the server. If
+	// the server is below that limit, it will repin underpinned files eve if it
+	// is not in the bottom X% in the cluster.
+	AlwaysPinThreshold = build.Select(
+		build.Var{
+			Standard: 50 * database.TiB,
+			Dev:      1 * database.MiB,
+			Testing:  1 * database.MiB,
+		}).(int)
+	// PinningRangeThresholdPercent defines the cutoff line in the list of
+	// servers, ordered by how much data they are pinning, below which a server
+	// will pin underpinned skylinks.
+	PinningRangeThresholdPercent = 30
 	// SleepBetweenPins defines how long we'll sleep between pinning files.
 	// We want to add this sleep in order to prevent a single server from
 	// grabbing all underpinned files and overloading itself. We also want to

--- a/workers/scanner.go
+++ b/workers/scanner.go
@@ -87,14 +87,6 @@ var (
 		Dev:      1 * time.Minute,
 		Testing:  500 * time.Millisecond,
 	}).(time.Duration)
-	// SleepBeforeForcedScan is used when we schedule a scan because something
-	// important happened with the cluster, i.e. a server was marked as dead or
-	// new empty servers were added and we want them to start repinning ASAP.
-	SleepBeforeForcedScan = build.Select(build.Var{
-		Standard: time.Hour,
-		Dev:      10 * time.Second,
-		Testing:  time.Second,
-	}).(time.Duration)
 	// sleepVariationFactor defines how much the sleep between scans will
 	// vary between executions. It represents percent.
 	sleepVariationFactor = 0.1

--- a/workers/scanner_test.go
+++ b/workers/scanner_test.go
@@ -447,3 +447,94 @@ func TestFindAndPinOneUnderpinnedSkylink(t *testing.T) {
 		t.Fatalf("Expected to find '%s' among the skylinks pinned by this server, got '%v'", sl.String(), sls)
 	}
 }
+
+// TestEligibleToPin makes sure that we can follow our eligibility rules:
+// - always eligible if below the hard limit
+// - always eligible if last
+// - eligible if in the last X%
+func TestEligibleToPin(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	ctx, cancel := test.Context()
+	defer cancel()
+	db, err := test.NewDatabase(ctx, t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := test.LoadTestConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	skydcm := skyd.NewSkydClientMock()
+	s := NewScanner(db, test.NewDiscardLogger(), cfg.MinPinners, cfg.ServerName, cfg.SleepBetweenScans, skydcm)
+
+	// Set the load levels for three other servers. The last one will be empty.
+	err1 := s.staticDB.SetServerLoad(ctx, "server1", 30*int64(AlwaysPinThreshold))
+	err2 := s.staticDB.SetServerLoad(ctx, "server2", 20*int64(AlwaysPinThreshold))
+	err3 := s.staticDB.SetServerLoad(ctx, "server3", 0)
+	if err = errors.Compose(err1, err2, err3); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check eligibility for a server that's not in the database.
+	// Expect an error.
+	_, err = s.staticEligibleToPin(ctx)
+	if !errors.Contains(err, database.ErrServerLoadNotFound) {
+		t.Fatalf("Expected '%v', got '%v'", database.ErrServerLoadNotFound, err)
+	}
+	// Set the server load level to a low level but not last.
+	// Bottom 50% but not bottom 30%. Still, below the hard limit, so we expect
+	// to be eligible.
+	err = s.staticDB.SetServerLoad(ctx, cfg.ServerName, int64(AlwaysPinThreshold)/2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eligible, err := s.staticEligibleToPin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !eligible {
+		t.Fatal("Expected to be eligible, wasn't.")
+	}
+	// Set the load level above the hard limit and above 30%.
+	// Expect not eligible.
+	err = s.staticDB.SetServerLoad(ctx, cfg.ServerName, 3*int64(AlwaysPinThreshold))
+	if err != nil {
+		t.Fatal(err)
+	}
+	eligible, err = s.staticEligibleToPin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if eligible {
+		t.Fatal("Expected to not be eligible, was.")
+	}
+	// Bump the load level of server3, so out current server is left last.
+	err = s.staticDB.SetServerLoad(ctx, "server3", 5*int64(AlwaysPinThreshold))
+	if err != nil {
+		t.Fatal(err)
+	}
+	eligible, err = s.staticEligibleToPin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !eligible {
+		t.Fatal("Expected to be eligible, wasn't.")
+	}
+	// Add one more server above our server, so we're not last but we're in the
+	// bottom 30%
+	err = s.staticDB.SetServerLoad(ctx, "server4", 6*int64(AlwaysPinThreshold))
+	if err != nil {
+		t.Fatal(err)
+	}
+	eligible, err = s.staticEligibleToPin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !eligible {
+		t.Fatal("Expected to be eligible, wasn't.")
+	}
+}


### PR DESCRIPTION

# PULL REQUEST

## Overview

The only servers which would automatically repin underpinned skylinks:
 - have less than 50TiB in contract data
 - are the server in the cluster with least data
 - are in the bottom 30% of all servers in the cluster by pinned data

## Example for Visual Changes

<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [ ] All git commits are signed. (REQUIRED)
- [ ] All new methods or updated methods have clear docstrings.
- [ ] Testing added or updated for new methods.
- [ ] Verified if any changes impact the WebPortal Health Checks.
- [ ] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed
Closes SKY-1078